### PR TITLE
Wrap lines at 80 chars

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,43 +1,68 @@
 # Informo specifications
 
-Welcome to Informo's specifications repository. Informo's specifications aim at giving a precise understanding of how Informo works.
+Welcome to Informo's specifications repository. Informo's specifications aim at
+giving a precise understanding of how Informo works.
 
-A live version of the specifications generated from the source files in this repository can be found at https://specs.informo.network/. This live version is generated from the `master` branch, and is re-deployed each time new commits are pushed to the said branch.
+A live version of the specifications generated from the source files in this
+repository can be found at https://specs.informo.network/. This live version is
+generated from the `master` branch, and is re-deployed each time new commits are
+pushed to the said branch.
 
 ## Build the documentation
 
-The specifications are built using [hugo](https://gohugo.io/), which you will need to install before being able to build it.
+The specifications are built using [hugo](https://gohugo.io/), which you will
+need to install before being able to build it.
 
-When cloning this repository, make sure to initialise and update its submodules, as the built version depends on an external theme which is referenced as a submodule:
+When cloning this repository, make sure to initialise and update its submodules,
+as the built version depends on an external theme which is referenced as a
+submodule:
 
 ```
 git clone https://github.com/Informo/specs --recurse-submodules
 ```
 
-Then just run `hugo` at the root of the repository. It will generate a static version of it in a `public` directory.
+Then just run `hugo` at the root of the repository. It will generate a static
+version of it in a `public` directory.
 
 ## Build the schemas
 
-For the sake of simplicity, this documentation uses SVG schemas, located in [/static/images](/static/images), in several locations. To make them render the same way for every platform, text font is converted to svg paths.
+For the sake of simplicity, this documentation uses SVG schemas, located in
+[/static/images](/static/images), in several locations. To make them render the
+same way for every platform, text font is converted to svg paths.
 
-A copy of the version with written text is available for each schema, with its name ending with `.src.svg`. After modifying one of those, text must be converted to paths again, by running `./svg-fonts-to-path.sh` from the root of the repository. The script uses [Inkscape](https://inkscape.org/), which must be installed on the system before generating the new versions of the schemas.
+A copy of the version with written text is available for each schema, with its
+name ending with `.src.svg`. After modifying one of those, text must be
+converted to paths again, by running `./svg-fonts-to-path.sh` from the root of
+the repository. The script uses [Inkscape](https://inkscape.org/), which must be
+installed on the system before generating the new versions of the schemas.
 
-The schemas have been initially generated on a GNU/Linux system using the "Sans" system font. In order to get a similar result, it is advised to perform any generation on a similar system.
+The schemas have been initially generated on a GNU/Linux system using the "Sans"
+system font. In order to get a similar result, it is advised to perform any
+generation on a similar system.
 
 ## Contribute
 
-Contributions to the Informo specifications are welcome. These must follow Informo's [Specifications Changes Submission Protocol](https://specs.informo.network/introduction/scsp/).
+Contributions to the Informo specifications are welcome. These must follow
+Informo's [Specifications Changes Submission
+Protocol](https://specs.informo.network/introduction/scsp/).
 
-While working on a submission, using hugo's watcher might be easier than manually running `hugo` each time you make a change:
+While working on a submission, using hugo's watcher might be easier than
+manually running `hugo` each time you make a change:
 
 ```
 hugo server
 ```
 
-This command must be run from the root of the repository. Hugo will start a webserver on `http://127.0.0.1:1313` (unless instructed otherwise), and rebuild (and reload) the site on every change.
+This command must be run from the root of the repository. Hugo will start a
+webserver on `http://127.0.0.1:1313` (unless instructed otherwise), and rebuild
+(and reload) the site on every change.
 
 ## Get in touch
 
-Whether it is to get to know Informo, to look for a way to contribute, or for any other reason, anyone is welcome to join the discussion and overall chatter in our [Matrix room](https://matrix.to/#/#discuss:weu.informo.network) or our [IRC channel](http://webchat.freenode.net?channels=%23informo).
+Whether it is to get to know Informo, to look for a way to contribute, or for
+any other reason, anyone is welcome to join the discussion and overall chatter
+in our [Matrix room](https://matrix.to/#/#discuss:weu.informo.network) or our
+[IRC channel](http://webchat.freenode.net?channels=%23informo).
 
-You can also reach the Informo core team in a more private way by sending an email to <core@informo.network>.
+You can also reach the Informo core team in a more private way by sending an
+email to <core@informo.network>.

--- a/content/information-distribution/_index.md
+++ b/content/information-distribution/_index.md
@@ -3,10 +3,22 @@ title: "Information distribution"
 weight: 3
 ---
 
-The main mission of Informo is distributing information. It does so by using a federated network made of nodes, which are servers implementing the [Matrix protocol specification](https://matrix.org/docs/spec/).
+The main mission of Informo is distributing information. It does so by using a
+federated network made of nodes, which are servers implementing the [Matrix
+protocol specification](https://matrix.org/docs/spec/).
 
-The Matrix specification defines an entity named "room", which can be considered as a federation of nodes interacting with each other. Every piece of content sent to a room is sent to every node involved in it. Informo uses a Matrix room to propagate every piece of information, with an official `informo.network` room administered by the [Informo core team](/informo/informo-core-team), however any external party is free to create its own room as long as information is distributed through it accordingly with the current specifications. Client implementations **should** allow users to retrieve information from several rooms.
+The Matrix specification defines an entity named "room", which can be considered
+as a federation of nodes interacting with each other. Every piece of content
+sent to a room is sent to every node involved in it. Informo uses a Matrix room
+to propagate every piece of information, with an official `informo.network` room
+administered by the [Informo core team](/informo/informo-core-team), however any
+external party is free to create its own room as long as information is
+distributed through it accordingly with the current specifications. Client
+implementations **should** allow users to retrieve information from several
+rooms.
 
 {{% notice info %}}
-Because of the nature of this section, its pages as of phase 1 are much lighter than in other sections, and will be completed once phase 2 begins.
+Because of the nature of this section, its pages as of phase
+1 are much lighter than in other sections, and will be completed once phase 2
+begins.
 {{% /notice %}}

--- a/content/information-distribution/article.md
+++ b/content/information-distribution/article.md
@@ -3,16 +3,31 @@ title: "Article"
 weight: 3
 ---
 
-An article is a news item published by a [source](/information-distribution/sources) to the Matrix room. It **must** include the item's content, title, author, date (formatted following the [ISO8601](https://tools.ietf.org/html/rfc3339) standard) and original URL (or an empty string if the item was only published through Informo), along with a signature coming from its source, and be published on the publication name space that has been declared by its source. The article **can** also include optional properties, such as the item's description, read duration, NSFW marker, etc..
+An article is a news item published by a
+[source](/information-distribution/sources) to the Matrix room. It **must**
+include the item's content, title, author, date (formatted following the
+[ISO8601](https://tools.ietf.org/html/rfc3339) standard) and original URL (or an
+empty string if the item was only published through Informo), along with a
+signature coming from its source, and be published on the publication name space
+that has been declared by its source. The article **can** also include optional
+properties, such as the item's description, read duration, NSFW marker, etc..
 
-The signature **must** be generated from one of the source's public signature verification keys (using the source's declared signing algorithm), and a string containing all of the item's information, and **must** be formatted the same way as follows:
+The signature **must** be generated from one of the source's public signature
+verification keys (using the source's declared signing algorithm), and a string
+containing all of the item's information, and **must** be formatted the same way
+as follows:
 
 ```
 title=Lorem ipsum&author=Cicero&date=2006-01-06T15:04-07:00&url=https://lipsum.com/&content=Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ```
 
-In the example string above, the target article is titled "Lorem ipsum", was written by "Cicero" on January 1st 2006 and can be found at "[https://lipsum.com/](https://lipsum.com/)" with the content "Lorem ipsum dolor sit amet, consectetur adipiscing elit.".
+In the example string above, the target article is titled "Lorem ipsum", was
+written by "Cicero" on January 1st 2006 and can be found at
+"[https://lipsum.com/](https://lipsum.com/)" with the content "Lorem ipsum dolor
+sit amet, consectetur adipiscing elit.".
 
-If the original news item contains media, these media **should** be uploaded to the node using [Matrix's content repository module](https://matrix.org/docs/spec/client_server/r0.4.0.html#id112).
+If the original news item contains media, these media **should** be uploaded to
+the node using [Matrix's content repository
+module](https://matrix.org/docs/spec/client_server/r0.4.0.html#id112).
 
 2️⃣: rest of the page

--- a/content/information-distribution/node.md
+++ b/content/information-distribution/node.md
@@ -3,23 +3,64 @@ title: "Node"
 weight: 1
 ---
 
-The federated network model Informo is based on is made of nodes communicating with each other. Technically speaking, a node refers to a piece of software implementing both the [client-server specification](https://matrix.org/docs/spec/client_server/r0.4.0.html) and the [federation specification](https://matrix.org/docs/spec/server_server/unstable.html) of the [Matrix protocol](https://matrix.org), and connected to one or more federations (i.e. Matrix rooms) which states and messages implements the Informo specifications.
+The federated network model Informo is based on is made of nodes communicating
+with each other. Technically speaking, a node refers to a piece of software
+implementing both the [client-server
+specification](https://matrix.org/docs/spec/client_server/r0.4.0.html) and the
+[federation
+specification](https://matrix.org/docs/spec/server_server/unstable.html) of the
+[Matrix protocol](https://matrix.org), and connected to one or more federations
+(i.e. Matrix rooms) which states and messages implements the Informo
+specifications.
 
-This page describes the behaviour nodes **must** implement in addition to the Matrix protocol specifications. From a technical point of view, this behaviour can be implemented either by embedding it in the piece of software implementing the Matrix specifications, or by using external tools that interact with the said piece of software.
+This page describes the behaviour nodes **must** implement in addition to the
+Matrix protocol specifications. From a technical point of view, this behaviour
+can be implemented either by embedding it in the piece of software implementing
+the Matrix specifications, or by using external tools that interact with the
+said piece of software.
 
 ## Ping
 
-When a message is sent by a user to a node `A`, this node will relay the message to every other node in the federation. If the link between `A` and another node `B` is broken for an indefinite amount of time (e.g. because of the network censoring any communication between `A` and `B`), `B` will never get the message. However, if another node `C` emits a message, and the link between `C` and `B` allows the latter to receive the message, `B` will notice a hole in the messages timeline and [request the missing message from `C`](https://matrix.org/docs/spec/server_server/unstable.html#post-matrix-federation-v1-get-missing-events-roomid).
+When a message is sent by a user to a node `A`, this node will relay the message
+to every other node in the federation. If the link between `A` and another node
+`B` is broken for an indefinite amount of time (e.g. because of the network
+censoring any communication between `A` and `B`), `B` will never get the
+message. However, if another node `C` emits a message, and the link between `C`
+and `B` allows the latter to receive the message, `B` will notice a hole in the
+messages timeline and [request the missing message from
+`C`](https://matrix.org/docs/spec/server_server/unstable.html#post-matrix-federation-v1-get-missing-events-roomid).
 
-In order to avoid a node being left out of a federation, nodes **must** send out a small message, named "ping" (2️⃣), to the Matrix room every twelve hours. This way, a node that's cut from most of a federation except for a few nodes will end up getting all of the information it missed. If a node is offline when it is supposed to send out a ping it **should** send it as soon as it gets back online.
+In order to avoid a node being left out of a federation, nodes **must** send out
+a small message, named "ping" (2️⃣), to the Matrix room every twelve hours. This
+way, a node that's cut from most of a federation except for a few nodes will end
+up getting all of the information it missed. If a node is offline when it is
+supposed to send out a ping it **should** send it as soon as it gets back
+online.
 
 ## Entry nodes
 
-An entry node is a node that allows client implementations to connect to the federations this node is in, and retrieve information from them. An entry node **must** allow guest access, and **must** define at least one [alias](https://matrix.org/docs/spec/client_server/r0.4.0.html#room-aliases) to the Matrix room.
+An entry node is a node that allows client implementations to connect to the
+federations this node is in, and retrieve information from them. An entry node
+**must** allow guest access, and **must** define at least one
+[alias](https://matrix.org/docs/spec/client_server/r0.4.0.html#room-aliases) to
+the Matrix room.
 
-Client implementations **must** provide users with an updated list of entry nodes with their addresses and the aliases to use to join the federation the node is in. Clients implementations **must** also provide users with a way to input custom values for the address of the entry node to use and the alias of the Matrix room to join.
+Client implementations **must** provide users with an updated list of entry
+nodes with their addresses and the aliases to use to join the federation the
+node is in. Clients implementations **must** also provide users with a way to
+input custom values for the address of the entry node to use and the alias of
+the Matrix room to join.
 
-Once a Matrix room is joined, client implementations **must** retrieve and save the [list of aliases](https://matrix.org/docs/spec/client_server/r0.4.0.html#m-room-aliases) for this room. In the event of an entry node that's currently being used being unreachable, clients implementations and **must** use this list to provide users with an updated list of alternative entry nodes and aliases to use. The address of the node managing a given alias can be retrieved through a [DNS query](https://github.com/matrix-org/synapse/#setting-up-federation). Client implementations **can** check for pings in order to filter out the inactive nodes from this list.
+Once a Matrix room is joined, client implementations **must** retrieve and save
+the [list of
+aliases](https://matrix.org/docs/spec/client_server/r0.4.0.html#m-room-aliases)
+for this room. In the event of an entry node that's currently being used being
+unreachable, clients implementations and **must** use this list to provide users
+with an updated list of alternative entry nodes and aliases to use. The address
+of the node managing a given alias can be retrieved through a [DNS
+query](https://github.com/matrix-org/synapse/#setting-up-federation). Client
+implementations **can** check for pings in order to filter out the inactive
+nodes from this list.
 
 {{% notice note %}}
 Nodes that aren't entry nodes are named "relay nodes".

--- a/content/information-distribution/source.md
+++ b/content/information-distribution/source.md
@@ -3,14 +3,32 @@ title: "Source"
 weight: 2
 ---
 
-A source is an entity holding the responsibility of publishing information through the Matrix room. Before publishing any information, a source **must** register itself as such on the room, including data on the organism or individual operating the source, the publication language and the publication name space (2️⃣: a Matrix event type), along with one or more public signature verification keys that will be used to assert the integrity of the information it publishes, and the signing algorithm used to generate the signature of its articles (`ed25519`, `hmac-sha256`, `hmac-sha512`, etc.).
+A source is an entity holding the responsibility of publishing information
+through the Matrix room. Before publishing any information, a source **must**
+register itself as such on the room, including data on the organism or
+individual operating the source, the publication language and the publication
+name space (2️⃣: a Matrix event type), along with one or more public signature
+verification keys that will be used to assert the integrity of the information
+it publishes, and the signing algorithm used to generate the signature of its
+articles (`ed25519`, `hmac-sha256`, `hmac-sha512`, etc.).
 
-A source **must** be trusted by trust authorities operated by organisms it trusts and is in contact with outside of Informo. If at least one of a source's private keys gets compromised, the source **must** update its list of public signature verification keys, and every trust authority trusting the source **must** compute and issue a new signature taking the updated list of keys into account. The reason behind this is to encourage trust authorities to communicate with their trusted sources, estimate how much compromised the source is (i.e. one key vs all of the keys vs the source's entire Matrix account), and take the actions it deems necessary.
+A source **must** be trusted by trust authorities operated by organisms it
+trusts and is in contact with outside of Informo. If at least one of a source's
+private keys gets compromised, the source **must** update its list of public
+signature verification keys, and every trust authority trusting the source
+**must** compute and issue a new signature taking the updated list of keys into
+account. The reason behind this is to encourage trust authorities to communicate
+with their trusted sources, estimate how much compromised the source is (i.e.
+one key vs all of the keys vs the source's entire Matrix account), and take the
+actions it deems necessary.
 
-In such an event, client implementations **should** consider articles posted prior to the key being compromised as possibly, but not surely trustworthy.
+In such an event, client implementations **should** consider articles posted
+prior to the key being compromised as possibly, but not surely trustworthy.
 
 {{% notice note %}}
-In the event of an organism or individual publishing information in several languages, this organism or individual **must** register a source for each publication language, with each registration containing the relevant data.
+In the event of an organism or individual publishing information in several
+languages, this organism or individual **must** register a source for each
+publication language, with each registration containing the relevant data.
 {{% /notice %}}
 
 2️⃣: rest of the page

--- a/content/informo/_index.md
+++ b/content/informo/_index.md
@@ -3,4 +3,7 @@ title: "Informo"
 weight: 2
 ---
 
-This section aims at helping people understand what Informo is. It features descriptions of the reason behind starting the project, the issues noticed in similar solutions and its strategy for addressing them, along with a short description of the group of people working on it.
+This section aims at helping people understand what Informo is. It features
+descriptions of the reason behind starting the project, the issues noticed in
+similar solutions and its strategy for addressing them, along with a short
+description of the group of people working on it.

--- a/content/informo/informo-core-team.md
+++ b/content/informo/informo-core-team.md
@@ -3,6 +3,16 @@ title: "The Informo core team"
 weight: 2
 ---
 
-The Informo core team represents the group of people that are in charge of maintaining the current specification, the informo.network infrastructure and most of the tools used around the Matrix protocol to make Informo possible. This team is made of people that either founded the project, or have been deemed, through their contributions to either the documentation, tools or discussions in Informo's public channels, trustworthy enough to be granted this kind of responsibilities by the rest of the team members.
+The Informo core team represents the group of people that are in charge of maintaining the
+current specification, the informo.network infrastructure and most of the tools
+used around the Matrix protocol to make Informo possible. This team is made of
+people that either founded the project, or have been deemed, through their
+contributions to either the documentation, tools or discussions in Informo's
+public channels, trustworthy enough to be granted this kind of responsibilities
+by the rest of the team members.
 
-The Informo core team also acts as a [trust authority](/trust-management/trust-authority), which mission is to asserts the trustworthiness of other trust authorities. It also administrates a Matrix room acting as the official informo.network federation, in which its trust authority is included in the room's suggested trust authorities.
+The Informo core team also acts as a [trust
+authority](/trust-management/trust-authority), which mission is to asserts the
+trustworthiness of other trust authorities. It also administrates a Matrix room
+acting as the official informo.network federation, in which its trust authority
+is included in the room's suggested trust authorities.

--- a/content/informo/what-is-informo.md
+++ b/content/informo/what-is-informo.md
@@ -3,28 +3,92 @@ title: "What is Informo"
 weight: 1
 ---
 
-**TL;DR**: Informo is a decentralised and federated network that enables people to share information and to bypass corporate or state censorship at some level.
+**TL;DR**: Informo is a decentralised and federated network that enables people
+to share information and to bypass corporate or state censorship at some level.
 
 ### Bypassing censorship of information done differently
 
-This section describes how most of other solutions used to bypass censorship of information work, and how identifying their shortcomings lead to start building Informo.
+This section describes how most of other solutions used to bypass censorship of
+information work, and how identifying their shortcomings lead to start building
+Informo.
 
-To describe the way most existing solutions work, let's consider [alice](https://github.com/NInfolab/alice) as an example, which is the censorship bypass solution currently in use by [Reporters Without Borders](https://rsf.org/en/) as part of their [Collateral Freedom](https://rsf.org/en/collateral-freedom) operation, and is representative of how most solutions work 👀.
+To describe the way most existing solutions work, let's consider
+[alice](https://github.com/NInfolab/alice) as an example, which is the
+censorship bypass solution currently in use by [Reporters Without
+Borders](https://rsf.org/en/) as part of their [Collateral
+Freedom](https://rsf.org/en/collateral-freedom) operation, and is representative
+of how most solutions work 👀.
 
-*alice* is basically a proxy/mirror that works by forwarding requests to a given website, and streams the data it receives back to the user 👀. This means that it needs to be "manually" set up on a server and configured with the websites to be proxy'd in order to work. To ensure availability, Reporters Without Borders hosts *alice* behind a CDN (*Content Delivery Network*), usually [Fastly](https://www.fastly.com/) or [Amazon's Cloudfront](https://aws.amazon.com/fr/cloudfront/). While these big players are usually considered a threat for privacy, they are also very popular and many websites and services depend on them. Blocking access to them would mean disrupting all of those services and damaging local businesses.
+*alice* is basically a proxy/mirror that works by forwarding requests to a given
+website, and streams the data it receives back to the user 👀. This means that
+it needs to be "manually" set up on a server and configured with the websites
+to be proxy'd in order to work. To ensure availability, Reporters Without
+Borders hosts *alice* behind a CDN (*Content Delivery Network*), usually
+[Fastly](https://www.fastly.com/) or [Amazon's
+Cloudfront](https://aws.amazon.com/fr/cloudfront/). While these big players are
+usually considered a threat for privacy, they are also very popular and many
+websites and services depend on them. Blocking access to them would mean
+disrupting all of those services and damaging local businesses.
 
-The address for each proxy is then both sent out to activists in the field and added to the list of proxies in the [RSF Censorship Detector browser extension](https://addons.mozilla.org/en-US/firefox/addon/rsf-censorship-detector/). This list is [hosted on GitHub](https://github.com/RSF-RWB/collateralfreedom/blob/master/sites.json) (for the same reason as the use of Fastly or Cloudfront), and downloaded by the extension at each start of the browser.
+The address for each proxy is then both sent out to activists in the field and
+added to the list of proxies in the [RSF Censorship Detector browser
+extension](https://addons.mozilla.org/en-US/firefox/addon/rsf-censorship-detector/).
+This list is [hosted on
+GitHub](https://github.com/RSF-RWB/collateralfreedom/blob/master/sites.json)
+(for the same reason as the use of Fastly or Cloudfront), and downloaded by the
+extension at each start of the browser.
 
-While it's an amazing solution to bypass state censorship, it comes with a few drawbacks. First, the administrators need to build an exhaustive list of the news sources that can be proxy'd. This can be considered a minor issue since the NGO (*Non-Governmental Organisation*) managing it is focused on the freedom of the press, but it still implies giving absolute trust to the said organization. Second, while blocking either Fastly or Cloudfront by a state is quite difficult, it is still possible for them to block each single sub-domain individually. In such an event, the administrators working on the Collateral Freedom operation would have to change the proxies' addresses to new ones and make them known to the relevant people by repeating the process described above.
+While it's an amazing solution to bypass state censorship, it comes with a few
+drawbacks. First, the administrators need to build an exhaustive list of the
+news sources that can be proxy'd. This can be considered a minor issue since the
+NGO (*Non-Governmental Organisation*) managing it is focused on the freedom of
+the press, but it still implies giving absolute trust to the said organization.
+Second, while blocking either Fastly or Cloudfront by a state is quite
+difficult, it is still possible for them to block each single sub-domain
+individually. In such an event, the administrators working on the Collateral
+Freedom operation would have to change the proxies' addresses to new ones and
+make them known to the relevant people by repeating the process described above.
 
 ### Bypassing censorship of information: the Informo way
 
-Informo aims at addressing the issues mentioned in the previous section, by considering the problem of censorship of information with a different angle. It uses a federated network of servers talking with each other using the [Matrix protocol](https://matrix.org/). A federation refers to a non-fixed set of parties that can talk to all of the others parties involved. The Matrix protocol defines ways to build such federations (named "rooms" in the protocol's specifications), and assures that the history of all data sent through the federation is saved by all of the parties involved.
+Informo aims at addressing the issues mentioned in the previous section, by
+considering the problem of censorship of information with a different angle. It
+uses a federated network of servers talking with each other using the [Matrix
+protocol](https://matrix.org/). A federation refers to a non-fixed set of
+parties that can talk to all of the others parties involved. The Matrix protocol
+defines ways to build such federations (named "rooms" in the protocol's
+specifications), and assures that the history of all data sent through the
+federation is saved by all of the parties involved.
 
-One of the key mission of Informo is to build a large network of nodes implementing the Matrix specification, spread as much as possible all around the world. This is why Informo needs to be open and collaborative, because it relies on giving people the ability to host their own node and expanding the network as much as possible. The bet behind this thinking is that, while it's relatively easy for a government or a company to block access to specific FQDN (*Fully qualified domain names*, e.g. `foo.example.com`) that will need human intervention to be renewed, it gets much more difficult when it comes to blocking access to an always-changing list of, let's say, hundreds of FQDN, knowing that the whole list must be denied access for the censorship to be effective, and that anyone in the world with sufficient technical knowledge (which Informo aims at keeping as low as possible) would be able to fire up another node and plug it to the existing network for access to be restored.
+One of the key mission of Informo is to build a large network of nodes
+implementing the Matrix specification, spread as much as possible all around the
+world. This is why Informo needs to be open and collaborative, because it relies
+on giving people the ability to host their own node and expanding the network as
+much as possible. The bet behind this thinking is that, while it's relatively
+easy for a government or a company to block access to specific FQDN (*Fully
+qualified domain names*, e.g. `foo.example.com`) that will need human
+intervention to be renewed, it gets much more difficult when it comes to
+blocking access to an always-changing list of, let's say, hundreds of FQDN,
+knowing that the whole list must be denied access for the censorship to be
+effective, and that anyone in the world with sufficient technical knowledge
+(which Informo aims at keeping as low as possible) would be able to fire up
+another node and plug it to the existing network for access to be restored.
 
-Regarding the trust issue described the first section, Informo also introduces a trust management mechanism, trying to set the balance between having to manually manage every person you trust, and having one person deciding for everyone who is trustworthy. In the current configuration, the Informo core team has slightly more privileges than other parties, since new users will be advised (but not forced) to start building their trust network by trusting Informo. While it's not an ideal situation, the Informo core team believes it is a step towards a less monolithic trust control.
+Regarding the trust issue described the first section, Informo also introduces a
+trust management mechanism, trying to set the balance between having to manually
+manage every person you trust, and having one person deciding for everyone who
+is trustworthy. In the current configuration, the Informo core team has slightly
+more privileges than other parties, since new users will be advised (but not
+forced) to start building their trust network by trusting Informo. While it's
+not an ideal situation, the Informo core team believes it is a step towards a
+less monolithic trust control.
 
 ### The meaning of "Informo"
 
-"Informo" is a word which means "information" in the Esperanto language. Because Informo is all about information, and making it accessible, it was only logical that the name was centered on the word "information". Esperanto fits perfectly with Informo's philosophy and needs for openness, as it is a language designed to be universal and usable by anyone to communicate with everyone. On top of that, the word itself sounded nice to the project's authors, thus was chosen as the project's name.
+"Informo" is a word which means "information" in the Esperanto language. Because
+Informo is all about information, and making it accessible, it was only logical
+that the name was centered on the word "information". Esperanto fits perfectly
+with Informo's philosophy and needs for openness, as it is a language designed
+to be universal and usable by anyone to communicate with everyone. On top of
+that, the word itself sounded nice to the project's authors, thus was chosen as
+the project's name.

--- a/content/introduction/_index.md
+++ b/content/introduction/_index.md
@@ -5,8 +5,18 @@ weight: 1
 
 Welcome to Informo's specifications.
 
-This documentation aims at giving the world a complete understanding of Informo's inner mechanisms, how it works and interacts with external elements in order to fulfil its mission. Informo needs to be as open and collaborative as possible for people to get involved, thus for it to work.
+This documentation aims at giving the world a complete understanding of
+Informo's inner mechanisms, how it works and interacts with external elements in
+order to fulfil its mission. Informo needs to be as open and collaborative as
+possible for people to get involved, thus for it to work.
 
-For this reason, this documentation is also open and collaborative, which means that anyone can submit changes requests by following the [specifications change submission protocol](/introduction/scsp).
+For this reason, this documentation is also open and collaborative, which means
+that anyone can submit changes requests by following the [specifications change
+submission protocol](/introduction/scsp).
 
-Any people wishing to get involved in any part of Informo, whether it is working on the specifications, contributing to the software we build, translations, or any other possible form of contribution (including taking part in the ongoing chatter about how to improve Informo) is more than welcome to join our [Matrix discussion room](https://matrix.to/#/!LppXGlMuWgaYNuljUr:weu.informo.network) or our [IRC channel](https://webchat.freenode.net/?channels=%23informo).
+Any people wishing to get involved in any part of Informo, whether it is working
+on the specifications, contributing to the software we build, translations, or
+any other possible form of contribution (including taking part in the ongoing
+chatter about how to improve Informo) is more than welcome to join our [Matrix
+discussion room](https://matrix.to/#/!LppXGlMuWgaYNuljUr:weu.informo.network) or
+our [IRC channel](https://webchat.freenode.net/?channels=%23informo).

--- a/content/introduction/about-this-documentation.md
+++ b/content/introduction/about-this-documentation.md
@@ -3,11 +3,17 @@ title: "About this documentation"
 weight: 1
 ---
 
-This documentation is built with [Hugo](https://gohugo.io/), using [Mathieu Cornic's "learn" theme](https://github.com/matcornic/hugo-theme-learn). It is distributed under the [GNU Free Documentation License](https://www.gnu.org/licenses/fdl-1.3.html).
+This documentation is built with [Hugo](https://gohugo.io/), using [Mathieu
+Cornic's "learn" theme](https://github.com/matcornic/hugo-theme-learn). It is
+distributed under the [GNU Free Documentation
+License](https://www.gnu.org/licenses/fdl-1.3.html).
 
 ## Key words
 
-This documentation includes key words which represent either an obligation, and interdiction, a possibility or a suggestion (depending on the word) directed to implementation maintainers. They are made recognisable by their use of a bold font style (e.g. "**must**"), and are listed below along with their meaning:
+This documentation includes key words which represent either an obligation, and
+interdiction, a possibility or a suggestion (depending on the word) directed to
+implementation maintainers. They are made recognisable by their use of a bold
+font style (e.g. "**must**"), and are listed below along with their meaning:
 
 * **must**: instruction, obligation
 * **should**: strong suggestion
@@ -17,21 +23,43 @@ This documentation includes key words which represent either an obligation, and 
 
 ## Emoji markers
 
-Some parts of this documentation are marked with an emoji, indicating a special status that will require the attention of an Informo core team member or specifications contributor in the future. They are mostly there to remind the relevant people of works in progress, and informing readers that the said people know there's work to do here (so there's no need to open a ticket about it). These are:
+Some parts of this documentation are marked with an emoji, indicating a special
+status that will require the attention of an Informo core team member or
+specifications contributor in the future. They are mostly there to remind the
+relevant people of works in progress, and informing readers that the said people
+know there's work to do here (so there's no need to open a ticket about it).
+These are:
 
-* 🔧 (`:wrench:`) This part of the documentation is incomplete and must be completed before a milestone can be reached.
-* 📝 (`:memo:`) This is a reference to a non existing resource that must be added in the future.
-* 👀 (`:eyes:`) The author of this part of the documentation is aware that, although they believe the information given here to be correct, they might not get the full picture, therefore give incomplete or incorrect information, and wishes to encourage discussions around this point (TL;DR: "imho, please correct if wrong").
-* 🕐 (`:clock1:`) This part of the documentation is only here temporarily for clarity purposes, and will be removed in a fixed point in the future.
-* 2️⃣ (`:two:`) This part of the documentation is incomplete, however the rest of it is to be added only uring phase 2 of the specifications' development.
+* 🔧 (`:wrench:`) This part of the documentation is incomplete and must be
+completed before a milestone can be reached.
+* 📝 (`:memo:`) This is a reference to a non existing resource that must be
+added in the future.
+* 👀 (`:eyes:`) The author of this part of the documentation is aware that,
+although they believe the information given here to be correct, they might not
+get the full picture, therefore give incomplete or incorrect information, and
+wishes to encourage discussions around this point (TL;DR: "imho, please
+correct if wrong").
+* 🕐 (`:clock1:`) This part of the documentation is only here temporarily for
+clarity purposes, and will be removed in a fixed point in the future.
+* 2️⃣ (`:two:`) This part of the documentation is incomplete, however the rest
+of it is to be added only during phase 2 of the specifications' development.
 
 ## Specifications development 🕐
 
-This part will be removed once a complete version of this documentation has been reached.
+This part will be removed once a complete version of this documentation has been
+reached.
 
 The Informo specifications' development will take place in two phases:
 
-* **phase 1** is building the overall documentation architecture. It focuses on getting the general outlines of the project written down, with the aim of getting it out as soon as possible so people can have a less vague idea of what Informo is about.
-* **phase 2** is adding in-depth documentation about Informo's inner mechanisms. It focuses on writing down the technical details of Informo, with the aim of enabling a future client implementation built from it.
+* **phase 1** is building the overall documentation architecture. It focuses on
+getting the general outlines of the project written down, with the aim of
+getting it out as soon as possible so people can have a less vague idea of
+what Informo is about.
+* **phase 2** is adding in-depth documentation about Informo's inner mechanisms.
+It focuses on writing down the technical details of Informo, with the aim of
+enabling a future client implementation built from it.
 
-  While phase 1 will mainly be done by the Informo core team, everyone is welcome to get involved in phase 2 and further, either by submitting changes or taking part in the discussions taking place in the discussion channels mentioned at the top of this page.
+While phase 1 will mainly be done by the Informo core team, everyone is welcome
+to get involved in phase 2 and further, either by submitting changes or taking
+part in the discussions taking place in the discussion channels mentioned at the
+top of this page.

--- a/content/introduction/scsp.md
+++ b/content/introduction/scsp.md
@@ -3,47 +3,102 @@ title: "Specifications Change Submission Protocol"
 weight: 2
 ---
 
-This page describes the protocol followed regarding the submission of any change of this documentation (also named "Specifications Changes Submission", shortened as "SCS"). This protocol is named "Specifications Change Submission Protocol" (which can be shortened to "SCSP").
+This page describes the protocol followed regarding the submission of any change
+of this documentation (also named "Specifications Changes Submission", shortened
+as "SCS"). This protocol is named "Specifications Change Submission Protocol"
+(which can be shortened to "SCSP").
 
-Any SCS **must** be done by opening a [pull request](https://help.github.com/articles/about-pull-requests/) against the specifications' GitHub repository (located [here](https://github.com/Informo/specs)). This can be done by either creating a fork of the repository and opening a pull request, or using the "Edit this page" button located on the top right corner of every page. The pull request's initial comment **must** include a brief description of the changes involved in this SCS, and a description of the issue it addresses. If the SCS addresses an issue that's already the target of an issue on the GitHub repository, the pull request's initial comment **must** also mention it.
+Any SCS **must** be done by opening a [pull
+request](https://help.github.com/articles/about-pull-requests/) against the
+specifications' GitHub repository (located
+[here](https://github.com/Informo/specs)). This can be done by either creating a
+fork of the repository and opening a pull request, or using the "Edit this page"
+button located on the top right corner of every page. The pull request's initial
+comment **must** include a brief description of the changes involved in this
+SCS, and a description of the issue it addresses. If the SCS addresses an issue
+that's already the target of an issue on the GitHub repository, the pull
+request's initial comment **must** also mention it.
 
-Once a pull request is open, a member of the [Informo core team](/informo/informo-core-team) will tag it using labels describing the type of the changes submitted and the current stage of the SCS (e.g. pending, merged, etc.). The Informo core team members are volunteers, and most of them have an occupation besides working on Informo-related projects, which means your submission might not be tagged as soon as you send it. Please keep that in mind when submitting your changes, and wait at least a week before complaining (politely) about it in our [discussion room](https://matrix.to/#/#discuss:weu.informo.network).
+Once a pull request is open, a member of the [Informo core
+team](/informo/informo-core-team) will tag it using labels describing the type
+of the changes submitted and the current stage of the SCS (e.g. pending, merged,
+etc.). The Informo core team members are volunteers, and most of them have an
+occupation besides working on Informo-related projects, which means your
+submission might not be tagged as soon as you send it. Please keep that in mind
+when submitting your changes, and wait at least a week before complaining
+(politely) about it in our [discussion
+room](https://matrix.to/#/#discuss:weu.informo.network).
 
-If you are unsure about whether changes should be made regarding a specific part of the specifications, or about whether you would have the time and/or resources to issue a SCS, feel free to discuss it with us by either [opening an issue](https://github.com/Informo/specs/issues/new) or joining our [discussion room](https://matrix.to/#/#discuss:weu.informo.network).
+If you are unsure about whether changes should be made regarding a specific part
+of the specifications, or about whether you would have the time and/or resources
+to issue a SCS, feel free to discuss it with us by either [opening an
+issue](https://github.com/Informo/specs/issues/new) or joining our [discussion
+room](https://matrix.to/#/#discuss:weu.informo.network).
 
-Below are described the different types of changes and the steps a submission matching one of them has to go through before being merged to this documentation.
+Below are described the different types of changes and the steps a submission
+matching one of them has to go through before being merged to this
+documentation.
 
 ## Typo, wording and phrasing
 
-A SCS fixing one or more spelling mistakes, or fixing bad wording and/or phrasing without altering any behaviour described by the specifications (nor adding any new one), **must** be tagged with the `type:typo` label.
+A SCS fixing one or more spelling mistakes, or fixing bad wording and/or
+phrasing without altering any behaviour described by the specifications (nor
+adding any new one), **must** be tagged with the `type:typo` label.
 
-On top of that, it **must** be tagged with only one label describing its state, which **must** be one of:
+On top of that, it **must** be tagged with only one label describing its state,
+which **must** be one of:
 
 * `scsp:pending`: this SCS is pending review.
-* `scsp:review`: a review of this SCS is under way by one of the Informo core team members. The review process for this type of SCS is described below.
+* `scsp:review`: a review of this SCS is under way by one of the Informo core
+team members. The review process for this type of SCS is described below.
 * `scsp:merged`: the SCS has been accepted and the pull request has been merged.
-* `scsp:won't merge`: the reviewer decided this SCS isn't fit for merging, and **must** justify their decision before closing the pull request.
+* `scsp:won't merge`: the reviewer decided this SCS isn't fit for merging, and
+**must** justify their decision before closing the pull request.
 
-The order of the tags as described above **should** (but might not, according to the situation) be representative of the SCS's life cycle.
+The order of the tags as described above **should** (but might not, according to
+the situation) be representative of the SCS's life cycle.
 
 ### Review process
 
-The review process starts with an initial review of the pull request by the Informo core team member using GitHub's review engine, during which the reviewer points out issues to address before the SCS can be accepted, and ends when an agreement on the changes to make is found between the reviewer and the SCS submitter.
+The review process starts with an initial review of the pull request by the
+Informo core team member using GitHub's review engine, during which the reviewer
+points out issues to address before the SCS can be accepted, and ends when an
+agreement on the changes to make is found between the reviewer and the SCS
+submitter.
 
 ## Behaviour change
 
-A SCS that's either adding a new behaviour to the specification or changing or removing an existing behaviour **must** be tagged with the `type:behaviour` label.
+A SCS that's either adding a new behaviour to the specification or changing or
+removing an existing behaviour **must** be tagged with the `type:behaviour`
+label.
 
-On top of that, it **must** be tagged with only one label describing its state, which **must** be one of:
+On top of that, it **must** be tagged with only one label describing its state,
+which **must** be one of:
 
-* `scsp:wip`: this SCS is a work in progress. This label can either be added by the pull request's author given they have sufficient rights to the repository, or following a request issued from the SCS's author to the Informo core team (either in the pull request's initial comment or in the [discussion room](https://matrix.to/#/#discuss:weu.informo.network)).
-* `scsp:review`: this SCS is ready for review. The review process for this type of SCS is described below.
-* `scsp:final review`: a final review of the SCS is under way by one of the Informo core team members. This step is optional and the SCS **must** only go through it if one or more of the Informo core team members strongly disagrees with the current state of the SCS. The review process is the same as the standard review process for a SCS tagged `type:typo`, and is described in the paragraph above.
+* `scsp:wip`: this SCS is a work in progress. This label can either be added by
+the pull request's author given they have sufficient rights to the repository,
+or following a request issued from the SCS's author to the Informo core team
+(either in the pull request's initial comment or in the [discussion
+room](https://matrix.to/#/#discuss:weu.informo.network)).
+* `scsp:review`: this SCS is ready for review. The review process for this type
+of SCS is described below.
+* `scsp:final review`: a final review of the SCS is under way by one of the
+Informo core team members. This step is optional and the SCS **must** only go
+through it if one or more of the Informo core team members strongly disagrees
+with the current state of the SCS. The review process is the same as the
+standard review process for a SCS tagged `type:typo`, and is described in the
+paragraph above.
 * `scsp:merged`: the SCS has been accepted and the pull request has been merged.
-* `scsp:won't merge`: an Informo core team member decided this SCS isn't fit for merging, and **must** justify their decision before closing the pull request.
+* `scsp:won't merge`: an Informo core team member decided this SCS isn't fit for
+merging, and **must** justify their decision before closing the pull request.
 
-The order of the tags as described above **should** (but might not, according to the situation) be representative of the SCS's life cycle.
+The order of the tags as described above **should** (but might not, according to
+the situation) be representative of the SCS's life cycle.
 
 ### Review process
 
-The review process starts as soon as the `scsp:review` label is added to the SCS's pull request. From then on, the SCS is available for public review for a total of 14 days (two weeks) 👀. During this period, anyone **can** issue a review on the SCS or comment and discuss it, preferably in the pull request's comments.
+The review process starts as soon as the `scsp:review` label is added to the
+SCS's pull request. From then on, the SCS is available for public review for a
+total of 14 days (two weeks) 👀. During this period, anyone **can** issue a
+review on the SCS or comment and discuss it, preferably in the pull request's
+comments.

--- a/content/introduction/terminology.md
+++ b/content/introduction/terminology.md
@@ -3,40 +3,71 @@ title: "Terminology"
 weight: 3
 ---
 
-The current section defines fixed definitions for words or expressions that are used over this documentation.
+The current section defines fixed definitions for words or expressions that are
+used over this documentation.
 
 #### Article
 
-An article refers to any news item that is sent over the Informo network. It is defined by its content, which, right now, is limited to text and images, and various metadata such as its title, its author(s), its publication date, etc..
+An article refers to any news item that is sent over the Informo network. It is
+defined by its content, which, right now, is limited to text and images, and
+various metadata such as its title, its author(s), its publication date, etc..
 
 #### Client implementation
 
-A client implementation is a piece of software implementing the related parts of the Informo specifications in order to allow users to connect to a federation and retrieve information from it.
+A client implementation is a piece of software implementing the related parts of
+the Informo specifications in order to allow users to connect to a federation
+and retrieve information from it.
 
 #### Federation
 
-A federation is a set of nodes that are able to communicate with each other, similar to a mesh network. In this specifications, Matrix rooms are sometimes referred to as federations, as they can be broadly considered as federations with state machines.
+A federation is a set of nodes that are able to communicate with each other,
+similar to a mesh network. In this specifications, Matrix rooms are sometimes
+referred to as federations, as they can be broadly considered as federations
+with state machines.
 
 #### Node
 
-A node is a piece of software implementing both the [client-server specification](https://matrix.org/docs/spec/client_server/r0.4.0.html) and the [federation specification](https://matrix.org/docs/spec/server_server/unstable.html) of the [Matrix protocol](https://matrix.org), and connected to one or more Informo federations.
+A node is a piece of software implementing both the [client-server
+specification](https://matrix.org/docs/spec/client_server/r0.4.0.html) and the
+[federation
+specification](https://matrix.org/docs/spec/server_server/unstable.html) of the
+[Matrix protocol](https://matrix.org), and connected to one or more Informo
+federations.
 
 #### Source, Information source
 
-An information source, sometimes referred to as just "source", refers to an individual or group of people that send articles over the Informo network. A source itself is defined by a name, a cryptographic key, and some metadata such as a description or an avatar. If supported by the Informo client in use, a user can subscribe to a source to add its latest articles to their feed.
+An information source, sometimes referred to as just "source", refers to an
+individual or group of people that send articles over the Informo network. A
+source itself is defined by a name, a cryptographic key, and some metadata such
+as a description or an avatar. If supported by the Informo client in use, a user
+can subscribe to a source to add its latest articles to their feed.
 
 #### Trust Authority (TA)
 
-A trust authority refers to an entity, whether it is an individual or a group of people, which role is to build up a list of sources it certifies as legit and worthy of trust. This list can also include trust authorities the TA certifies as qualified to state on the trust worthiness of other sources.
+A trust authority refers to an entity, whether it is an individual or a group of
+people, which role is to build up a list of sources it certifies as legit and
+worthy of trust. This list can also include trust authorities the TA certifies
+as qualified to state on the trust worthiness of other sources.
 
 #### Trust Level
 
-The trust level is an indication on how much a client implementation trusts a trust authority. It is a relative integer representing the maximum depth in the user's trust network that can be reached from the said trust authority. It can be either defined by the user (to control what its client must trust as precisely as possible) or by a trust authority for another trust authority (to delegate the certification of trustworthiness).
+The trust level is an indication on how much a client implementation trusts a
+trust authority. It is a relative integer representing the maximum depth in the
+user's trust network that can be reached from the said trust authority. It can
+be either defined by the user (to control what its client must trust as
+precisely as possible) or by a trust authority for another trust authority (to
+delegate the certification of trustworthiness).
 
 #### Trust Link
 
-A trust link is an unidirectional connection between a user or trust authority and another trust authority they trust. The concept is similar to the edges in [graph theory](https://en.wikipedia.org/wiki/Graph_theory).
+A trust link is an unidirectional connection between a user or trust authority
+and another trust authority they trust. The concept is similar to the edges in
+[graph theory](https://en.wikipedia.org/wiki/Graph_theory).
 
 #### Trust network, Trust chain
 
-A user's trust network, also referred to as their trust chain, is the network formed by the trust authorities and sources they trust, either directly or indirectly. If explicitly specified as such, these expressions can also refer to the network formed by all of the trust authorities and sources known within Informo's federated network.
+A user's trust network, also referred to as their trust chain, is the network
+formed by the trust authorities and sources they trust, either directly or
+indirectly. If explicitly specified as such, these expressions can also refer to
+the network formed by all of the trust authorities and sources known within
+Informo's federated network.

--- a/content/trust-management/_index.md
+++ b/content/trust-management/_index.md
@@ -3,10 +3,33 @@ title: "Trust management"
 weight: 4
 ---
 
-One of Informo's key issues is to allow as much information as possible through the federated network, with some level of mitigation against intentional disinformation or propaganda. The set of mechanisms used to address this is called "trust management" in this documentation.
+One of Informo's key issues is to allow as much information as possible through
+the federated network, with some level of mitigation against intentional
+disinformation or propaganda. The set of mechanisms used to address this is
+called "trust management" in this documentation.
 
-Informo's trust management system is designed to ensure as much as possible the integrity and the origin of all of the information traveling through the federation, and the identity of all parties involved. It aims at building a trust network made of cryptographic signatures users can rely on, possibly starting from signing keys that are embedded into client implementations, all the way to the information itself. the idea is to consider the network hostile, therefore relying as much as possible on operations that are local and/or hard to interfere with. This is done by relying on [trust authorities](/trust-management/trust-authority), which are third-party organisms such as NGOs and non-profit organisations, to certify the trustworthiness of an [information source](/information-distribution/source), which itself certifies the integrity of the information it publishes.
+Informo's trust management system is designed to ensure as much as possible the
+integrity and the origin of all of the information traveling through the
+federation, and the identity of all parties involved. It aims at building a
+trust network made of cryptographic signatures users can rely on, possibly
+starting from signing keys that are embedded into client implementations, all
+the way to the information itself. the idea is to consider the network hostile,
+therefore relying as much as possible on operations that are local and/or hard
+to interfere with. This is done by relying on [trust
+authorities](/trust-management/trust-authority), which are third-party organisms
+such as NGOs and non-profit organisations, to certify the trustworthiness of an
+[information source](/information-distribution/source), which itself certifies
+the integrity of the information it publishes.
 
-In order not to prevent the network to act as a censorship machine, Informo has to keep trust management optional, meaning it **must** let everyone publish information through the network and let everyone read all of the information that has been published through the network (i.e. without blocking access to anything or including any sort of strong filtering based on parameters the user doesn't control). With this in mind, trust management **must** be a process that ends up giving the user only an indication on whether a news item might be trustworthy or not, letting them make their own choice on whether or not bypass this indication.
+In order not to prevent the network to act as a censorship machine, Informo has
+to keep trust management optional, meaning it **must** let everyone publish
+information through the network and let everyone read all of the information
+that has been published through the network (i.e. without blocking access to
+anything or including any sort of strong filtering based on parameters the user
+doesn't control). With this in mind, trust management **must** be a process that
+ends up giving the user only an indication on whether a news item might be
+trustworthy or not, letting them make their own choice on whether or not bypass
+this indication.
 
-This section describes how Informo's trust management mechanisms must work with all the related parties involved.
+This section describes how Informo's trust management mechanisms must work with
+all the related parties involved.

--- a/content/trust-management/trust-authority.md
+++ b/content/trust-management/trust-authority.md
@@ -3,40 +3,100 @@ title: "Trust authority"
 weight: 1
 ---
 
-One key party of Informo's trust management mechanisms is called "trust authorities", often also referred as "TA". As defined in [this documentation's terminology](/introduction/terminology/#trust-authority-ta), a trust authority is an entity that asserts the trustworthiness of another entity, whether this entity is an information source or another trust authority. It does so by using asymmetric cryptographic signatures.
+One key party of Informo's trust management mechanisms is called "trust
+authorities", often also referred as "TA". As defined in [this documentation's
+terminology](/introduction/terminology/#trust-authority-ta), a trust authority
+is an entity that asserts the trustworthiness of another entity, whether this
+entity is an information source or another trust authority. It does so by using
+asymmetric cryptographic signatures.
 
-A user **must** be able to chose which TA they want to give their absolute trust to, whether that TA is itself trusted by another TA or not. This model follows the outlines of [Delegative Democracy](https://en.wikipedia.org/wiki/Delegative_democracy), as it allows a user to either trust a source based on their own research and criteria, or delegate the assertion of a source's trustworthiness to another party.
+A user **must** be able to chose which TA they want to give their absolute trust
+to, whether that TA is itself trusted by another TA or not. This model follows
+the outlines of [Delegative
+Democracy](https://en.wikipedia.org/wiki/Delegative_democracy), as it allows a
+user to either trust a source based on their own research and criteria, or
+delegate the assertion of a source's trustworthiness to another party.
 
-A trust authority's main responsibility is to assert the trustworthiness of a source or of another TA. This means that the TA **must** publish a list of all of the sources and TAs it trusts, keep it up to date, and give the information needed to certify the sources' and TAs' authenticity.
+A trust authority's main responsibility is to assert the trustworthiness of a
+source or of another TA. This means that the TA **must** publish a list of all
+of the sources and TAs it trusts, keep it up to date, and give the information
+needed to certify the sources' and TAs' authenticity.
 
-If a user chooses to trust a specific TA, let's name it *SomeNGO.org* here for the sake of simplicity, all sources and TAs trusted by *SomeNGO.org* **must** be considered as trustworthy by client implementations in accordance with their chosen trust level (documented in [the related section](/trust-management/trust-level/)).
+If a user chooses to trust a specific TA, let's name it *SomeNGO.org* here for
+the sake of simplicity, all sources and TAs trusted by *SomeNGO.org* **must** be
+considered as trustworthy by client implementations in accordance with their
+chosen trust level (documented in [the related
+section](/trust-management/trust-level/)).
 
-A trust authority **can** specify a reason for trusting another TA or a source. If specified, this reason **must** consist in a custom localised string provided in by the trust authority.
+A trust authority **can** specify a reason for trusting another TA or a source.
+If specified, this reason **must** consist in a custom localised string provided
+in by the trust authority.
 
-A trust authority **must** also be able to list sources and trust authorities that it explicitly blacklists for being compromised or ethical reasons. The trust authority **must** specify a reason for blacklisting a source or TA, which consists in a defined reason code (2️⃣). The trust authority **can** also provide additional information to explain the addition to the blacklist, which, if provided, **must** be contained in a custom localised string.
+A trust authority **must** also be able to list sources and trust authorities
+that it explicitly blacklists for being compromised or ethical reasons. The
+trust authority **must** specify a reason for blacklisting a source or TA, which
+consists in a defined reason code (2️⃣). The trust authority **can** also
+provide additional information to explain the addition to the blacklist, which,
+if provided, **must** be contained in a custom localised string.
 
 ### Trust authority registration
 
-A trust authority **must** register itself as such on the Matrix room. This registration **must** include data on the organism operating the TA, along with the list of its public signature verification keys and the list of all of the sources and trust authorities it trusts. This list **must** include, for each trusted source and TA, a signature generated from one of the TA's public keys. This signature **must** be generated from a string containing the identifier (2️⃣: MXID), type (either "source" or "trust_authority") public name and list of public keys of the specific source or TA, and **must** be formatted the same way as follows:
+A trust authority **must** register itself as such on the Matrix room. This
+registration **must** include data on the organism operating the TA, along with
+the list of its public signature verification keys and the list of all of the
+sources and trust authorities it trusts. This list **must** include, for each
+trusted source and TA, a signature generated from one of the TA's public keys.
+This signature **must** be generated from a string containing the identifier
+(2️⃣: MXID), type (either "source" or "trust_authority") public name and list of
+public keys of the specific source or TA, and **must** be formatted the same way
+as follows:
 
 ```
 id=@acmenews:weu.informo.network&type=source&name=ACME News&keys=[somekey,someotherkey]
 ```
 
-In the example string above, the target entity is a source using the identifier `@acmenews:weu.informo.network`, the public name `ACME News` and `somekey` and `someotherkey` as its public signature verification keys.
+In the example string above, the target entity is a source using the identifier
+`@acmenews:weu.informo.network`, the public name `ACME News` and `somekey` and
+`someotherkey` as its public signature verification keys.
 
-A TA's registration **must** associate each signature with the identifier of the trusted source or TA, and with the signing algorithm used to generate it (`ed25519`, `hmac-sha256`, `hmac-sha512`, etc.).
+A TA's registration **must** associate each signature with the identifier of the
+trusted source or TA, and with the signing algorithm used to generate it
+(`ed25519`, `hmac-sha256`, `hmac-sha512`, etc.).
 
-In the event of one of a TA's private keys being compromised, it **must** update its list of public signature verification keys by removing the compromised key (and adding one new key or more to the said list), and the other trust authorities trusting this TA **must** compute and issue a new signature taking the updated list of keys into account.
+In the event of one of a TA's private keys being compromised, it **must** update
+its list of public signature verification keys by removing the compromised key
+(and adding one new key or more to the said list), and the other trust
+authorities trusting this TA **must** compute and issue a new signature taking
+the updated list of keys into account.
 
 ## Suggested trust authority
 
-In order to guide a new user through building his trusted network when they enters a Matrix room (i.e. an Informo federation), the room's administrator **can** provide a list of suggested TAs (2️⃣: stored in Matrix room state). These TAs will be proposed to the users if they doesn't know which TA they should trust first.
+In order to guide a new user through building his trusted network when they
+enters a Matrix room (i.e. an Informo federation), the room's administrator
+**can** provide a list of suggested TAs (2️⃣: stored in Matrix room state).
+These TAs will be proposed to the users if they doesn't know which TA they
+should trust first.
 
-As an additional security step, the client implementation maintainer **should** add the suggested trust authorities' public signature verification keys to the implementation's code base, so the user doesn't retrieve these keys through a potentially insecure network. This is an important step because these TAs represent the foundations of the user's trust network. In the event of an embedded public key getting compromised, trust authorities **must** make implementation maintainers aware of it, and implementation maintainers **must** release another version of their implementation which **must not** include the compromised key.
+As an additional security step, the client implementation maintainer **should**
+add the suggested trust authorities' public signature verification keys to the
+implementation's code base, so the user doesn't retrieve these keys through a
+potentially insecure network. This is an important step because these TAs
+represent the foundations of the user's trust network. In the event of an
+embedded public key getting compromised, trust authorities **must** make
+implementation maintainers aware of it, and implementation maintainers **must**
+release another version of their implementation which **must not** include the
+compromised key.
 
 ## Client implementations
 
-In the event of a source being trusted by a TA *A* and blacklisted by a TA *B*, given that both *A* and *B* are being trusted by the user, client implementations **must** display a warning to users, indicating that, although some of the user's trusted TAs are still asserting the source as being trustworthy, some others explicitly stated that the source should not be trusted anymore, mentioning the reasons specified in the corresponding blacklist entry.
+In the event of a source being trusted by a TA *A* and blacklisted by a TA *B*,
+given that both *A* and *B* are being trusted by the user, client
+implementations **must** display a warning to users, indicating that, although
+some of the user's trusted TAs are still asserting the source as being
+trustworthy, some others explicitly stated that the source should not be trusted
+anymore, mentioning the reasons specified in the corresponding blacklist entry.
 
-In order to help its users assert the trustworthiness of a source, a client **might** include the display of a graph showing the location of the source in Informo's trust network. It **might** also include a view promoting sources that have been certified as trustworthy by several TAs that the user trusts.
+In order to help its users assert the trustworthiness of a source, a client
+**might** include the display of a graph showing the location of the source in
+Informo's trust network. It **might** also include a view promoting sources that
+have been certified as trustworthy by several TAs that the user trusts.

--- a/content/trust-management/trust-level.md
+++ b/content/trust-management/trust-level.md
@@ -3,21 +3,37 @@ title: "Trust level"
 weight: 2
 ---
 
-A TA's trust level is a relative integer which represents the depth in the trust management chain which trustworthiness is asserted by this TA.
+A TA's trust level is a relative integer which represents the depth in the trust
+management chain which trustworthiness is asserted by this TA.
 
 This page mentions two kinds of trust levels, which are:
 
-* link trust level, which is a defined value associated with the trust link between either the user and a TA, or between a TA and another TA it trusts.
-* effective trust level, which is the final value the client **must** use as the TA's trust level, whether it is the value defined for one of the above, or the result of a computation involving either (or several) of these.
+* link trust level, which is a defined value associated with the trust link
+between either the user and a TA, or between a TA and another TA it trusts.
+* effective trust level, which is the final value the client **must** use as the
+TA's trust level, whether it is the value defined for one of the above, or the
+result of a computation involving either (or several) of these.
 
 A trust authority's effective trust level is to be understood as follows:
 
-* A trust level of 0 means that only the sources trusted by this TA **must** be considered trustworthy by the client.
-* A trust level of 1 means that both the sources and the trust authorities trusted by this TA **must** be considered trustworthy by the client (which means all trust authorities trusted by this TA **must** be considered with an effective trust level of 0).
-* A trust level of 2 means that all of the sources this TA certifies to be trustworthy **must** be considered trustworthy by the client, and all of the trust authorities this TA certifies as trustworthy **must** be considered with an effective trust level of 1.
+* A trust level of 0 means that only the sources trusted by this TA **must** be
+considered trustworthy by the client.
+* A trust level of 1 means that both the sources and the trust authorities
+trusted by this TA **must** be considered trustworthy by the client (which
+means all trust authorities trusted by this TA **must** be considered with an
+effective trust level of 0).
+* A trust level of 2 means that all of the sources this TA certifies to be
+trustworthy **must** be considered trustworthy by the client, and all of the
+trust authorities this TA certifies as trustworthy **must** be considered with
+an effective trust level of 1.
 * *Et cetera*...
 
-A trust authority holding a negative trust level means that this TA **must not** be trusted. The absolute value of a negative effective trust level **can**, however, be used by a client implementation in order to compute the distance in the user's trust network between the trust authority and the closest trusted TA and estimate the likelihood of the TA being trustworthy based on that distance, in order to make suggestions on TAs and sources to trust to the user.
+A trust authority holding a negative trust level means that this TA **must not**
+be trusted. The absolute value of a negative effective trust level **can**,
+however, be used by a client implementation in order to compute the distance in
+the user's trust network between the trust authority and the closest trusted TA
+and estimate the likelihood of the TA being trustworthy based on that distance,
+in order to make suggestions on TAs and sources to trust to the user.
 
 ## Calculating trust level
 
@@ -29,19 +45,28 @@ Let's consider:
 
 * `A`, `B`, `C` and `D` four example TAs.
 * `TL(x)` a function returning the effective trust level for the TA `x`.
-* `LTL(x,y)` a function returning the trust level of the link between `x` (being either a TA or the user) and the TA `y`.
-* `max(x,y)` a function returning the highest value between the integers `x` and `y`.
-* `min(x,y)` a function returning the lowest value between the integers `x` and `y`.
+* `LTL(x,y)` a function returning the trust level of the link between `x` (being
+either a TA or the user) and the TA `y`.
+* `max(x,y)` a function returning the highest value between the integers `x` and
+`y`.
+* `min(x,y)` a function returning the lowest value between the integers `x` and
+`y`.
 * `C` trusted by both `A` and `B`.
 * `D` trusted by `C`.
 
-In this situation, the effective trust level of `D` **must** be both inferior to `TL(C)` and inferior or equal to `LTL(C,D)`, i.e. `TL(D) <= min(TL(C)-1, LTL(C,D))`. Client implementations **should** generally use the highest possible value, but they **can** also use lower values in order to provide stricter trust management.
+In this situation, the effective trust level of `D` **must** be both inferior to
+`TL(C)` and inferior or equal to `LTL(C,D)`, i.e. `TL(D) <= min(TL(C)-1,
+LTL(C,D))`. Client implementations **should** generally use the highest possible
+value, but they **can** also use lower values in order to provide stricter trust
+management.
 
-The effective trust level of `C` **must** be the highest trust level value calculated for each link (`A➡️C` and `B➡️C`) using the rule above.
+The effective trust level of `C` **must** be the highest trust level value
+calculated for each link (`A➡️C` and `B➡️C`) using the rule above.
 
 #### General rule
 
-In a general manner, the effective trust level of any TA named `𝑋` that is trusted by multiple TAs named `A`, `B`, `C`, ... can be expressed as :
+In a general manner, the effective trust level of any TA named `𝑋` that is
+trusted by multiple TAs named `A`, `B`, `C`, ... can be expressed as :
 
 ```
 TL(𝑋) <= max(
@@ -54,23 +79,53 @@ TL(𝑋) <= max(
 
 #### User trusting a TA
 
-A user can choose to trust a specific TA, which overrides the computed value for this TA's effective trust level, thus ignores any value calculated using the general rule above.
+A user can choose to trust a specific TA, which overrides the computed value for
+this TA's effective trust level, thus ignores any value calculated using the
+general rule above.
 
-If the user trusts a TA with a specific trust level, the TA's effective trust level **must** be equal to this user-defined value. This lets the user limit the depth of its trust network.
+If the user trusts a TA with a specific trust level, the TA's effective trust
+level **must** be equal to this user-defined value. This lets the user limit the
+depth of its trust network.
 
-If the user trusts a TA `A` with no specific trust level, a TA `B` trusted by `A` **should** be trusted by the user with an effective trust level equal to the link trust level `A` defines for `B`. This lets the user fully trust both the TA and its trust network. Client implementation **can** do this by using an infinite value for `A`'s effective trust level.
-
+If the user trusts a TA `A` with no specific trust level, a TA `B` trusted by
+`A` **should** be trusted by the user with an effective trust level equal to the
+link trust level `A` defines for `B`. This lets the user fully trust both the TA
+and its trust network. Client implementation **can** do this by using an
+infinite value for `A`'s effective trust level.
 
 ## Examples
 
+Let's consider:
+
+* `TL(x)` a function returning the effective trust level for the TA `x`.
+* `LTL(x,y)` a function returning the trust level of the link between `x` (being
+either a TA or the user) and the TA `y`.
+
+* `min(x,y)` a function returning the lowest value between the integers `x` and
+`y`.
+* the schema below:
+
 ![](/images/trust-level-graph.svg?width=100%)
 
-- `B` trusts `C` with a trust level of 1. `TL(C) = min(TL(B) - 1, TL(B,C)) = min(1 - 1, 1) = 0`.
-- `A` trusts `E` with a trust level of 0. `TL(E) = min(TL(A) - 1, TL(A,E)) = min(2 - 1, 0) = 0`.
-- `TL(D) < 0`, meaning TA and its sources are not trusted.
+In this example, and because of the rules stated above, it is interesting to
+note that:
 
-This is what happens if the user decides to trusts `E`:
+* `B` trusts `C` with a trust level of 1 (i.e. `LTL(B,C) = 1`). However, `TL(B) =
+1` in the user's trust network, and `TL(C) < TL(B)`, so `TL(C)` is brought
+down to 0. This can also be expressed as `TL(C) = min(TL(B)-1, TL(B,C)) =
+min(1-1, 1) = 0`.
+* The same rule applies to `TL(D)`. This means that `TL(D) < 0`, so `D` isn't
+trusted.
+* `LTL(A,E) = 0`, which means that `A` explicitly states not to trust any TA
+trusted by `E`, causing `F` to be untrusted. `TL(E)` can also be expressed as
+`TL(E) = min(TL(A)-1, LTL(A,E)) = min(2-1, 0) = 0`.
+
+Let's consider the user trusting `E`:
+
 ![](/images/trust-level-graph-userdef2.svg?width=100%)
 
-- `TL(E)` is overridden unconditionally by the `TL(user,E)` value.
-- `F` is now trusted.
+In the schema above, it is interesting to note that, now:
+
+- `LTL(user,E)` is being overridden by a user-defined value of 1 (we know it because it would otherwise equal `LTL(E,F)+1 = 2`).
+- Because there's now a trust link between the user and `E` and it takes precedence over any other trust link targeting `E`, `TL(E) = 1`
+- `F` is now trusted because `min(TL(E) - 1 , LTL(E,F)) = 0`.


### PR DESCRIPTION
Wrap all lines at 80 characters.

Also re-introduced the reviewed example for trust level that was introduced at https://github.com/Informo/specs/commit/45b84e51dbfaf76d0c21d3f19a8501e1317b401a but was somehow replaced by the previous version.

Also fixed a typo on the "About this documentation" page.