### PR TITLE
Shorter SCSP behaviour review duration

### DIFF
--- a/content/introduction/scsp.md
+++ b/content/introduction/scsp.md
@@ -99,6 +99,6 @@ the situation) be representative of the SCS's life cycle.
 
 The review process starts as soon as the `scsp:review` label is added to the
 SCS's pull request. From then on, the SCS is available for public review for a
-total of 14 days (two weeks) 👀. During this period, anyone **can** issue a
+total of 7 days (one weeks). During this period, anyone **can** issue a
 review on the SCS or comment and discuss it, preferably in the pull request's
 comments.

--- a/content/introduction/scsp.md
+++ b/content/introduction/scsp.md
@@ -99,6 +99,5 @@ the situation) be representative of the SCS's life cycle.
 
 The review process starts as soon as the `scsp:review` label is added to the
 SCS's pull request. From then on, the SCS is available for public review for a
-total of 7 days (one weeks). During this period, anyone **can** issue a
-review on the SCS or comment and discuss it, preferably in the pull request's
-comments.
+total of 7 days (one week). During this period, anyone **can** issue a review on
+the SCS or comment and discuss it, preferably in the pull request's comments.


### PR DESCRIPTION
Since we are early in development and there will be a lot of SCS for adding new features, which may also depend on other SCS. The current 2-week review duration will probably slow down a bit too much the initial development process.
The review duration will probably be restored to 2 weeks when the ground work is finished.

Note: Specs bot will need to be updated to display 7 days instead of 14 when this is merged.