### PR TITLE
Matrix event signing

### DIFF
--- a/content/information-distribution/article.md
+++ b/content/information-distribution/article.md
@@ -13,8 +13,8 @@ that has been declared by its source. The article **can** also include optional
 properties, such as the item's description, read duration, NSFW marker, etc..
 
 If the source has one or more signature keys, the article JSON object **must**
-be signed with one of the source's keys, using the [Canonical JSON
-method](/information-distribution/signature/#signing-json-data)
+be signed with one of the source's keys, as described in the [Signature
+section](/information-distribution/signature/#signing-json-data).
 
 If the source has no signature keys, then signing the article is recommended but
 optional.
@@ -24,3 +24,5 @@ the node using [Matrix's content repository
 module](https://matrix.org/docs/spec/client_server/r0.4.0.html#id112).
 🔧: Media signature
 
+
+2️⃣: rest of the page

--- a/content/information-distribution/article.md
+++ b/content/information-distribution/article.md
@@ -12,22 +12,15 @@ signature coming from its source, and be published on the publication name space
 that has been declared by its source. The article **can** also include optional
 properties, such as the item's description, read duration, NSFW marker, etc..
 
-The signature **must** be generated from one of the source's public signature
-verification keys (using the source's declared signing algorithm), and a string
-containing all of the item's information, and **must** be formatted the same way
-as follows:
+If the source has one or more signature keys, the article JSON object **must**
+be signed with one of the source's keys, using the [Canonical JSON
+method](/information-distribution/signature/#signing-json-data)
 
-```
-title=Lorem ipsum&author=Cicero&date=2006-01-06T15:04-07:00&url=https://lipsum.com/&content=Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-```
-
-In the example string above, the target article is titled "Lorem ipsum", was
-written by "Cicero" on January 1st 2006 and can be found at
-"[https://lipsum.com/](https://lipsum.com/)" with the content "Lorem ipsum dolor
-sit amet, consectetur adipiscing elit.".
+If the source has no signature keys, then signing the article is recommended but
+optional.
 
 If the original news item contains media, these media **should** be uploaded to
 the node using [Matrix's content repository
 module](https://matrix.org/docs/spec/client_server/r0.4.0.html#id112).
+🔧: Media signature
 
-2️⃣: rest of the page

--- a/content/information-distribution/article.md
+++ b/content/information-distribution/article.md
@@ -12,8 +12,9 @@ signature coming from its source, and be published on the publication name space
 that has been declared by its source. The article **can** also include optional
 properties, such as the item's description, read duration, NSFW marker, etc..
 
-The article JSON object **must** be encapsulated in a [signed matrix
-event](/information-distribution/signature), using one of the source's keys.
+The article JSON object **must** be encapsulated in a [signed Matrix
+event](/information-distribution/signature), with its signature generated with
+one of the source's keys.
 
 If the original news item contains media, these media **should** be uploaded to
 the node using [Matrix's content repository

--- a/content/information-distribution/article.md
+++ b/content/information-distribution/article.md
@@ -12,17 +12,12 @@ signature coming from its source, and be published on the publication name space
 that has been declared by its source. The article **can** also include optional
 properties, such as the item's description, read duration, NSFW marker, etc..
 
-If the source has one or more signature keys, the article JSON object **must**
-be signed with one of the source's keys, as described in the [Signature
-section](/information-distribution/signature/#signing-json-data).
-
-If the source has no signature keys, then signing the article is recommended but
-optional.
+The article JSON object **must** be encapsulated in a [signed matrix
+event](/information-distribution/signature), using one of the source's keys.
 
 If the original news item contains media, these media **should** be uploaded to
 the node using [Matrix's content repository
 module](https://matrix.org/docs/spec/client_server/r0.4.0.html#id112).
 🔧: Media signature
-
 
 2️⃣: rest of the page

--- a/content/information-distribution/signature.md
+++ b/content/information-distribution/signature.md
@@ -1,0 +1,60 @@
+---
+title: "Signature"
+weight: 4
+---
+
+Informo relies on cryptographic signatures in order to verify the integrity of
+data shared across the federation. These signatures are generated using
+asymmetric cryptography keys (`ed25519`, `hmac-sha256`, `hmac-sha512`, etc.),
+which private key solely owned by the end user.
+
+
+## Signed Matrix event
+
+### Event data
+
+Informo signed events are built using a common structure, inspired from [Matrix
+`m.room.encrypted`
+events](https://matrix.org/speculator/spec/HEAD/client_server/unstable.html#m-room-encrypted):
+
+|    Field     |   Type   |                                    Description                                    |
+| ------------ | -------- | --------------------------------------------------------------------------------- |
+| `algorithm`  | `string` | Algorithm used for signing the content. 🔧 Define allowed algorithms               |
+| `sender_key` | `string` | The public part of the key used for signing the event                             |
+| `device_id`  | `string` | 🔧 Optional, ID of the sending device, may be used for Megolm                      |
+| `session_id` | `string` | 🔧 Optional, ID of the session used to encrypt the message, may be used for Megolm |
+| `signature`  | `string` | Generated signature                                                               |
+| `signed`     | `object` | Event signed content                                                              |
+
+🔧: Need to do some research on Megolm and Matrix APIs around encryption and key
+management
+
+Example:
+
+```json
+{
+    "content": {
+        "algorithm": "ed25519"
+        "sender_key": "IlRMeOPX2e0MurIyfWEucYBRVOEEUMrOHqn/8mLqMjA"
+        "signature": "0a1df56f1c3ab5b1"
+        "signed": {
+            // Event signed JSON data
+        }
+    }
+}
+```
+
+### Signing JSON data
+
+Signing JSON data require some additional steps since the same JSON data can be
+serialized in many different ways.
+
+JSON objects are generally represented as hash maps, causing object content to
+be ordered by their hash value, which can vary a lot between platforms and
+implementations. JSON data can also contain an arbitrary number of whitespaces
+as separators.
+
+In order to produce consistent JSON strings, clients **must** convert the JSON
+data into a [Canonical JSON
+string](https://matrix.org/speculator/spec/HEAD/appendices.html#canonical-json),
+before signing it and setting the event's `content.signature` field.

--- a/content/information-distribution/signature.md
+++ b/content/information-distribution/signature.md
@@ -15,7 +15,7 @@ which private key solely owned by the end user.
 
 Informo signed events are built using a common structure, inspired from [Matrix
 `m.room.encrypted`
-events](https://matrix.org/speculator/spec/HEAD/client_server/unstable.html#m-room-encrypted):
+events](https://matrix.org/docs/spec/client_server/r0.4.0.html#m-room-encrypted):
 
 |    Field     |   Type   |                                    Description                                    |
 | ------------ | -------- | --------------------------------------------------------------------------------- |
@@ -24,19 +24,19 @@ events](https://matrix.org/speculator/spec/HEAD/client_server/unstable.html#m-ro
 | `device_id`  | `string` | 🔧 Optional, ID of the sending device, may be used for Megolm                      |
 | `session_id` | `string` | 🔧 Optional, ID of the session used to encrypt the message, may be used for Megolm |
 | `signature`  | `string` | Generated signature                                                               |
-| `signed`     | `object` | Event signed content                                                              |
+| `signed`     | `object` | Content that has been signed                                                      |
 
-🔧: Need to do some research on Megolm and Matrix APIs around encryption and key
-management
+<!-- 🔧: Need to do some research on Megolm and Matrix APIs around encryption and key
+management -->
 
 Example:
 
 ```json
 {
     "content": {
-        "algorithm": "ed25519"
-        "sender_key": "IlRMeOPX2e0MurIyfWEucYBRVOEEUMrOHqn/8mLqMjA"
-        "signature": "0a1df56f1c3ab5b1"
+        "algorithm": "ed25519",
+        "sender_key": "IlRMeOPX2e0MurIyfWEucYBRVOEEUMrOHqn/8mLqMjA",
+        "signature": "0a1df56f1c3ab5b1",
         "signed": {
             // Event signed JSON data
         }
@@ -56,5 +56,5 @@ as separators.
 
 In order to produce consistent JSON strings, clients **must** convert the JSON
 data into a [Canonical JSON
-string](https://matrix.org/speculator/spec/HEAD/appendices.html#canonical-json),
-before signing it and setting the event's `content.signature` field.
+string](https://matrix.org/docs/spec/appendices.html#canonical-json), before
+signing it and setting the event's `content.signature` field.

--- a/content/trust-management/trust-authority.md
+++ b/content/trust-management/trust-authority.md
@@ -46,9 +46,9 @@ registration **must** include data on the organism operating the TA, along with
 the list of its public signature verification keys and the list of all of the
 sources and trust authorities it trusts. This list **must** include, for each
 trusted source and TA, a signature generated from one of the TA's public keys.
-This signature **must** be generated from the source's Matrix event content
-using the [Canonical JSON
-method](/information-distribution/signature/#signing-json-data).
+This signature **must** be generated from the source's Matrix event content as
+described in the [Signature
+section](/information-distribution/signature/#signing-json-data).
 
 A TA's registration **must** associate each signature with the identifier of the
 trusted source or TA, and with the signing algorithm used to generate it

--- a/content/trust-management/trust-authority.md
+++ b/content/trust-management/trust-authority.md
@@ -46,18 +46,9 @@ registration **must** include data on the organism operating the TA, along with
 the list of its public signature verification keys and the list of all of the
 sources and trust authorities it trusts. This list **must** include, for each
 trusted source and TA, a signature generated from one of the TA's public keys.
-This signature **must** be generated from a string containing the identifier
-(2️⃣: MXID), type (either "source" or "trust_authority") public name and list of
-public keys of the specific source or TA, and **must** be formatted the same way
-as follows:
-
-```
-id=@acmenews:weu.informo.network&type=source&name=ACME News&keys=[somekey,someotherkey]
-```
-
-In the example string above, the target entity is a source using the identifier
-`@acmenews:weu.informo.network`, the public name `ACME News` and `somekey` and
-`someotherkey` as its public signature verification keys.
+This signature **must** be generated from the source's Matrix event content
+using the [Canonical JSON
+method](/information-distribution/signature/#signing-json-data).
 
 A TA's registration **must** associate each signature with the identifier of the
 trusted source or TA, and with the signing algorithm used to generate it


### PR DESCRIPTION
tl;dr Informo signed events should follow this structure:
```json
{
    "content": {
        "algorithm": "ed25519"
        "sender_key": "IlRMeOPX2e0MurIyfWEucYBRVOEEUMrOHqn/8mLqMjA"
        "signature": "0a1df56f1c3ab5b1"
        "signed": {
            // Event signed JSON data
        }
    }
}
```

Also adds some instruction for how to sign JSON object data