### PR TITLE
Rewrite introduction to include a brief description of Informo

### DIFF
--- a/content/informo/what-is-informo.md
+++ b/content/informo/what-is-informo.md
@@ -77,11 +77,11 @@ another node and plug it to the existing network for access to be restored.
 Regarding the trust issue described the first section, Informo also introduces a
 trust management mechanism, trying to set the balance between having to manually
 manage every person you trust, and having one person deciding for everyone who
-is trustworthy. In the current configuration, the Informo core team has slightly
-more privileges than other parties, since new users will be advised (but not
-forced) to start building their trust network by trusting Informo. While it's
-not an ideal situation, the Informo core team believes it is a step towards a
-less monolithic trust control.
+is trustworthy. In the current configuration, the administrators of a federation
+have slightly more privileges than other parties, since new users will be
+advised (but not forced) to start building their trust network by trusting a set
+of suggested entities. While it's not an ideal situation, we believes it is a
+step towards a less monolithic trust control.
 
 ### The meaning of "Informo"
 

--- a/content/introduction/_index.md
+++ b/content/introduction/_index.md
@@ -41,6 +41,9 @@ This significantly hampers censorship because:
 You can learn more about Informo's approach on [this dedicated
 page](/informo/what-is-informo/).
 
+The technical details for the distribution of information through the federation
+are described in [their own section](/information-distribution).
+
 On top of that, Informo also provides trust management mechanisms which are
 designed to let readers have a reliable idea of who an information source really
 is without having to rely on a potentially insecure network. This set of

--- a/content/introduction/_index.md
+++ b/content/introduction/_index.md
@@ -11,7 +11,7 @@ order to fulfil its mission.
 
 Informo needs to be as open and collaborative as possible for people to get
 involved, thus for it to work. For this reason, this documentation is also open
-and collaborative, which means that anyone can submit changes requests by
+and collaborative, which means that anyone can submit change requests by
 following the [specifications change submission protocol](/introduction/scsp).
 
 ### What is Informo?

--- a/content/introduction/_index.md
+++ b/content/introduction/_index.md
@@ -3,16 +3,50 @@ title: "Introduction"
 weight: 1
 ---
 
-Welcome to Informo's specifications.
+### Welcome to Informo's specifications
 
 This documentation aims at giving the world a complete understanding of
 Informo's inner mechanisms, how it works and interacts with external elements in
-order to fulfil its mission. Informo needs to be as open and collaborative as
-possible for people to get involved, thus for it to work.
+order to fulfil its mission.
 
-For this reason, this documentation is also open and collaborative, which means
-that anyone can submit changes requests by following the [specifications change
-submission protocol](/introduction/scsp).
+Informo needs to be as open and collaborative as possible for people to get
+involved, thus for it to work. For this reason, this documentation is also open
+and collaborative, which means that anyone can submit changes requests by
+following the [specifications change submission protocol](/introduction/scsp).
+
+### What is Informo?
+
+Informo is a project aiming to fight online censorship of information by
+allowing information sources to share their news through a federation of servers
+(i.e. a group of servers that can talk to each other) using [the Matrix
+protocol](https://matrix.org). Matrix allows the information to be shared
+between a potentially large amount of servers, each storing their own copy and
+serving it to anyone requesting it.
+
+This significantly hampers censorship because:
+
+* every server knows about the information, the whole federation must be
+  blocked in order to censor it. The list of servers participating in a
+  federation can continuously grow and change, which can render such a blockade
+  practically very hard, if not impossible, to manage.
+
+* the Matrix protocol is built upon
+  [HTTP](https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol), which is
+  one of the most (if not the most) used protocols over the Internet, rendering
+  the identification of Matrix traffic (and therefore Informo traffic) hard (but
+  not impossible) to identify. On top of that, using security protocols such as
+  [TLS](https://en.wikipedia.org/wiki/Transport_Layer_Security) would render
+  such identification even harder
+
+You can learn more about Informo's approach on [this dedicated
+page](/informo/what-is-informo/).
+
+On top of that, Informo also provides trust management mechanisms which are
+designed to let readers have a reliable idea of who an information source really
+is without having to rely on a potentially insecure network. This set of
+mechanisms is described in [its own section](/trust-management).
+
+### Get involved!
 
 Any people wishing to get involved in any part of Informo, whether it is working
 on the specifications, contributing to the software we build, translations, or

--- a/content/introduction/_index.md
+++ b/content/introduction/_index.md
@@ -45,8 +45,8 @@ The technical details for the distribution of information through the federation
 are described in [their own section](/information-distribution).
 
 On top of that, Informo also provides trust management mechanisms which are
-designed to let readers have a reliable idea of who an information source really
-is without having to rely on a potentially insecure network. This set of
+designed to let readers have a reliable idea of the origin and authenticity of a
+news item without having to rely on a potentially insecure network. This set of
 mechanisms is described in [its own section](/trust-management).
 
 ### Get involved!

--- a/content/introduction/_index.md
+++ b/content/introduction/_index.md
@@ -36,7 +36,7 @@ This significantly hampers censorship because:
   the identification of Matrix traffic (and therefore Informo traffic) hard (but
   not impossible) to identify. On top of that, using security protocols such as
   [TLS](https://en.wikipedia.org/wiki/Transport_Layer_Security) would render
-  such identification even harder
+  such identification even harder.
 
 You can learn more about Informo's approach on [this dedicated
 page](/informo/what-is-informo/).

--- a/content/introduction/_index.md
+++ b/content/introduction/_index.md
@@ -25,7 +25,7 @@ serving it to anyone requesting it.
 
 This significantly hampers censorship because:
 
-* every server knows about the information, the whole federation must be
+* every server knows about the information, so the whole federation must be
   blocked in order to censor it. The list of servers participating in a
   federation can continuously grow and change, which can render such a blockade
   practically very hard, if not impossible, to manage.


### PR DESCRIPTION
After talking about Informo with a few people, I realised most of them didn't really know what it's about, or how it was supposed to work, despite there being an entire page dedicated to that matter.

One thing that would help in a major way would be to have a short description about Informo in the introduction page, so newcomers can get a broad idea of what it is with starting points if they're interested in diving deeper into it, instead of having to look for that information through the specs website.

Although it doesn't technically introduce a change in behaviour, I'm tagging the SCS as such so people can have some time to give it a look and share their feedback, in order to hopefully end up with the most newcomer-friendly intro possible.

I've also used this as an opportunity to rewrite part of a paragraph in the "What is Informo?" page to bring it up to date with the general tone of the specs.

[Click here for rendered version](https://github.com/Informo/specs/blob/vabd/intro/content/introduction/_index.md)