### PR TITLE
Make the logo link depend on the site's base URL

### DIFF
--- a/layouts/partials/logo.html
+++ b/layouts/partials/logo.html
@@ -1,5 +1,5 @@
 <h1>
-<a id="logo" href="/introduction">
+<a id="logo" href="{{"/introduction" | relURL}}">
 
 <svg
    style="vertical-align: text-bottom;"


### PR DESCRIPTION
Turns out that the link in the logo was hardcoded as `/introduction`. This makes Hugo transform it into a relative URL built from the site's base URL.