### PR TITLE
Proposal of alternative mechanism to identify entry nodes

### DIFF
--- a/content/information-distribution/node.md
+++ b/content/information-distribution/node.md
@@ -156,9 +156,15 @@ request](https://matrix.org/docs/spec/client_server/r0.4.0.html#post-matrix-clie
 to the selected node using the federation's room ID.
 
 In order to optimise the likelihood of success of the join request, client
-implementations **should** provide at least 3 nodes to join the federation
-through using `server_name` query parameters. Client implementations don't need
-to make sure that these nodes are entry nodes in this case.
+implementations **should** provide server names for at least additional 3 nodes
+when performing the join request using `server_name` query parameters. This will
+ensure that, if the node doesn't already have at least one user in the
+federation, it can fall back by asking another node (either of the 3 or more
+provided) which does to [help it
+join](https://matrix.org/docs/spec/server_server/r0.1.1.html#get-matrix-federation-v1-make-join-roomid-userid).
+These nodes are used only by the entry node, and only during this interaction,
+therefore client implementations don't need to make sure that these nodes are
+entry nodes in this case.
 
 While connected to a node, client implementations **should** keep track of
 received pings in order to better filter out inactive nodes when the entry node

--- a/content/information-distribution/node.md
+++ b/content/information-distribution/node.md
@@ -55,15 +55,20 @@ following structure:
 |:-------------|:-------|:----:|:--------------------------------------------------------------|
 | `entry_node` | `bool` |  x   | Whether the node is an entry node for this federation (room). |
 
-One entry of this map **can** be the wildcard value "`*`" instead of a Matrix room ID, in which case it means its content defines default values for the parameters it contains.
+One entry of this map **can** be the wildcard value "`*`" instead of a Matrix
+room ID, in which case it means its content defines default values for the
+parameters it contains.
 
-If the file lacks a wildcard entry, or the wildcard entry's content lacks one or more parameter(s), the following default values **must** be used for the missing parameter(s):
+If the file lacks a wildcard entry, or the wildcard entry's content lacks one or
+more parameter(s), the following default values **must** be used for the missing
+parameter(s):
 
 | Parameter    | Default value |
 |:-------------|:--------------|
 | `entry_node` | `false`       |
 
-If an entry exists for a federation and its content define different values for any parameters, these values **must** be used for this federation.
+If an entry exists for a federation and its content define different values for
+any parameters, these values **must** be used for this federation.
 
 ### Simple example
 

--- a/content/information-distribution/node.md
+++ b/content/information-distribution/node.md
@@ -44,8 +44,7 @@ This ping **must** take the form of a Matrix timeline event of the
 
 An entry node is a node that allows client implementations to connect to the
 federations this node is in, and retrieve information from them. An entry node
-**must** allow guest access and **must** have at least one user in every
-federation they want to give users access to.
+**must** allow guest access.
 
 On top of that, an entry node **must** expose a file at the address
 `https://SERVER_NAME/.well-known/informo/info` which content is a map in the

--- a/content/information-distribution/node.md
+++ b/content/information-distribution/node.md
@@ -105,7 +105,7 @@ registration state event up to date, the former's administrators are less likely
 to have changed their minds and not act as an entry node anymore than the
 latter.
 
-Client implementations **must not** try to fetch the `.well-known/informo/info`
+Client implementations **must not** try to fetch the `/.well-known/informo/info`
 file of each node once it has computed this list, because this would be harmful
 to its users' privacy.
 

--- a/content/information-distribution/node.md
+++ b/content/information-distribution/node.md
@@ -155,9 +155,13 @@ federation to join.
 
 When reaching a node in order to join a federation, client implementations
 **must** try to retrieve the `/.well-kown/informo/info` file of the node (while
-following 30x redirects). If the file doesn't exist, or doesn't explicitly state
-that the node can be used as an entry node for the given federation, then client
-implementations **must** give up and try another node.
+following 30x redirects). If the file doesn't exist, or doesn't state that the
+node can be used as an entry node for the given federation, then client
+implementations **must** give up and try another node. While trying to use this
+node as an entry node anyway can be technically working, this rule exists in
+order to avoid node administrators possible legal issues resulting from people
+using a node to access specific types of contents against its administrator's
+will.
 
 Client implementations **should** store the result of the attempt at retrieving
 the `/.well-kown/informo/info` file of a node in a cache with a time-based

--- a/content/information-distribution/node.md
+++ b/content/information-distribution/node.md
@@ -55,9 +55,15 @@ following structure:
 |:-------------|:-------|:----:|:--------------------------------------------------------------|
 | `entry_node` | `bool` |  x   | Whether the node is an entry node for this federation (room). |
 
-One entry of this map **can** be the wildcard value "`*`" instead of a Matrix
-room ID, in which case it means its content apply to every federation with the
-exception of any federation mentioned as a key in the map.
+One entry of this map **can** be the wildcard value "`*`" instead of a Matrix room ID, in which case it means its content defines default values for the parameters it contains.
+
+If the file lacks a wildcard entry, or the wildcard entry's content lacks one or more parameter(s), the following default values **must** be used for the missing parameter(s):
+
+| Parameter    | Default value |
+|:-------------|:--------------|
+| `entry_node` | `false`       |
+
+If an entry exists for a federation and its content define different values for any parameters, these values **must** be used for this federation.
 
 ### Simple example
 

--- a/content/information-distribution/node.md
+++ b/content/information-distribution/node.md
@@ -55,7 +55,11 @@ following structure:
 |:-------------|:-------|:----:|:--------------------------------------------------------------|
 | `entry_node` | `bool` |  x   | Whether the node is an entry node for this federation (room). |
 
-### Example
+One entry of this map **can** be the wildcard value "`*`" instead of a Matrix
+room ID, in which case it means its content apply to every federation with the
+exception of any federation mentioned as a key in the map.
+
+### Simple example
 
 Let's consider a node that has `example.com` as its server name, and wants to
 act as an entry node for the federation which Matrix room ID is
@@ -68,6 +72,26 @@ This node **must** serve a file at the address
 {
     "!Nei7aeg5aefub:informo.network": {
         "entry_node": true
+    }
+}
+```
+
+### Blacklist example
+
+Let's consider the a node that has `example.com` as its server name and wants to
+act as an entry node to any federation except for the one which Matrix room ID
+is `!Nei7aeg5aefub:informo.network`.
+
+This node **must** serve a file at the address
+`https://example.com/.well-known/informo/info` with the following content:
+
+```
+{
+    "*": {
+        "entry_node": true
+    },
+    "!Nei7aeg5aefub:informo.network": {
+        "entry_node": false
     }
 }
 ```

--- a/content/information-distribution/node.md
+++ b/content/information-distribution/node.md
@@ -97,7 +97,7 @@ Matrix users belonging to a given node in a federation. The thinking behind this
 is that a node with many users in a federation is more likely to be an entry
 node for this federation than a node with only a few users in it.
 
-Client implementations **should** also weight this list accordint to the number
+Client implementations **should** also weight this list according to the number
 of trusted [TAs]({{<ref "/trust-management/trust-authority">}}) that trust a
 given node. A node that's trusted by a TA **should** weight more than a node
 trusted by no TA but has many users. Since TAs are expected to keep their

--- a/content/information-distribution/node.md
+++ b/content/information-distribution/node.md
@@ -93,17 +93,8 @@ implementations **must** save this list in case the node they're currently using
 becomes unreachable.
 
 Client implementations **should** weight this list according to the number of
-Matrix users belonging to a given node in a federation. The thinking behind this
-is that a node with many users in a federation is more likely to be an entry
-node for this federation than a node with only a few users in it.
-
-Client implementations **should** also weight this list according to the number
-of trusted [TAs]({{<ref "/trust-management/trust-authority">}}) that trust a
-given node. A node that's trusted by a TA **should** weight more than a node
-trusted by no TA but has many users. Since TAs are expected to keep their
-registration state event up to date, the former's administrators are less likely
-to have changed their minds and not act as an entry node anymore than the
-latter.
+trusted [TAs]({{<ref "/trust-management/trust-authority">}}) that trust a given
+node.
 
 Client implementations **must not** try to fetch the `/.well-known/informo/info`
 file of each node once it has computed this list, because this would be harmful

--- a/content/information-distribution/node.md
+++ b/content/information-distribution/node.md
@@ -145,7 +145,8 @@ that the node can be used as an entry node for the given federation, then client
 implementations **must** give up and try another node.
 
 Client implementations **should** store the result of the attempt at retrieving
-the `/.well-kown/informo/info` file of a node in a cache.
+the `/.well-kown/informo/info` file of a node in a cache with a time-based
+invalidation policy.
 
 Once both an entry node and a room ID have been selected as the one to use in
 order to join a federation, whether this selection originated from an explicit

--- a/content/information-distribution/node.md
+++ b/content/information-distribution/node.md
@@ -126,12 +126,12 @@ to its users' privacy.
 
 #### Reaching an entry node
 
-Because a list of entry nodes only contains the nodes' server names, and not
-their host names, a node might not be reachable at the address defined by its
-server name. As an example, the Matrix specifications would allow a node living
-at `node.example.com` to use Matrix identifiers ending with `:example.com`.
+A list of entry nodes only contains the nodes' server names, and not their
+address and port, which can differ. As an example, the Matrix specifications
+would allow a node living at `node.example.com` to use Matrix identifiers ending
+with `:example.com`.
 
-In order to find the effective host name and port to reach a node at, client
+In order to find the effective address and port to reach a node at, client
 implementations **must** implement the server discovery through `.well-known`
 URI logic, as [described in the Matrix
 specifications](https://matrix.org/docs/spec/client_server/r0.4.0.html#server-discovery).
@@ -139,7 +139,8 @@ specifications](https://matrix.org/docs/spec/client_server/r0.4.0.html#server-di
 {{% notice note %}}
 If the server discovery leads to a final `IGNORE` instruction (as specified in
 the link above), then client implementations **must** use the node's server name
-as the host name the node can be reached at.
+as the address and port the node can be reached at, using the `443` port as a
+default value.
 {{% /notice %}}
 
 In the event of an entry node that's currently being used becoming unreachable,


### PR DESCRIPTION
Fixes #43

This proposal introduces a mechanism to discover entry nodes and manage client implementations' lists of entry nodes that doesn't involve using aliases, but instead processing the rest of the room's state and a file in the .well-known namespace.

Rendered: https://specs.informo.network/scs/45/information-distribution/node/