### PR TITLE
Proposal for a way for sources to sign articles' media

### DIFF
--- a/content/information-distribution/article.md
+++ b/content/information-distribution/article.md
@@ -13,7 +13,7 @@ The article JSON object **must** be encapsulated in a [signed Matrix
 event]({{<ref "/information-distribution/signature">}}), with its signature
 generated with one of the source's keys.
 
-If the original news item contains media, these media **should** be uploaded to
+If the original news item contains media, these media **must** be uploaded to
 the node using [Matrix's content repository
 module](https://matrix.org/docs/spec/client_server/r0.4.0.html#id112) and their
 cryptographic signatures **should** be appended to the article's event.
@@ -54,6 +54,8 @@ Where:
   users. The `mxc://` URL **can** refer to any media included either in the
   article's content or in any other property in the event's data (such as its
   thumbnail).
+
+
 
 Additional information:
 

--- a/content/information-distribution/article.md
+++ b/content/information-distribution/article.md
@@ -52,8 +52,8 @@ Where:
   signature of the media that's been uploaded at this URL. This signature
   **must** be generated using the same algorithm and public key that were used
   to sign the article's event. If this is not the case, or the signature can't
-  be verified, client implementations **must not** display the media to their
-  users. The `mxc://` URL **can** refer to any media included either in the
+  be verified, client implementations **must not** display the medium to their
+  users. The `mxc://` URL **can** refer to any medium included either in the
   article's content or in any other property in the event's data (such as its
   thumbnail).
 

--- a/content/information-distribution/article.md
+++ b/content/information-distribution/article.md
@@ -16,7 +16,9 @@ generated with one of the source's keys.
 If the original news item contains media, these media **must** be uploaded to
 the node using [Matrix's content repository
 module](https://matrix.org/docs/spec/client_server/r0.4.0.html#id112) and their
-cryptographic signatures **should** be appended to the article's event.
+cryptographic signatures **must** be appended to the article's event. Client
+implementations **must not** display media that aren't served by a node's
+content repository endpoint.
 
 ## Matrix event `network.informo.article`
 
@@ -40,7 +42,7 @@ become visible.
 | `thumbnail`         | `string`          |      | Preview image for the article. Must be a [`mxc://` URL](https://matrix.org/docs/spec/client_server/r0.4.0.html#id112).                     |
 | `date`              | `int`             |      | Timestamp in milliseconds of the article's publication. If not provided clients should fall back to the Matrix event's creation timestamp. |
 | `content`           | `string`          |  x   | Article HTML content. The HTML **must** be sanitized before being displayed in a client.                                                   |
-| `media_sigs`        | `MediaSignatures` |      | Cryptographic signatures of the media embedded in the article.                                                                             |
+| `media_sigs`        | `MediaSignatures` |  !   | Cryptographic signatures of the media embedded in the article. Required if the article contains at least one medium.                       |
 | `custom`            | `object`          |      | Additional information for custom client implementations.                                                                                  |
 
 Where:
@@ -54,8 +56,6 @@ Where:
   users. The `mxc://` URL **can** refer to any media included either in the
   article's content or in any other property in the event's data (such as its
   thumbnail).
-
-
 
 Additional information:
 


### PR DESCRIPTION
Fixes #46 

This is necessary since otherwise there's no warranty that a malicious third party won't MITM and replace media, or that a malicious node won't intentionally serve the wrong media. This can get particularly dangerous, e.g. if a government tries to replace communication material from an opposing party with dangerous or misleading reproductions.

Rendered: https://specs.informo.network/scs/48/information-distribution/article/